### PR TITLE
spoqa sans글꼴은 chrome이외의 웹브라우저에서 안티-알리아싱이 안되는 문제가 있어서 noto sans 글꼴(구글 …

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-@import url(http://spoqa.github.io/spoqa-han-sans/css/SpoqaHanSans-kr.css);
+@import url(http://fonts.googleapis.com/earlyaccess/notosanskr.css);
 html, body {
     overflow-x: initial !important;
 }
@@ -15,7 +15,7 @@ body {
     top: 0px;
     left: 0px;
     right: 0px;
-    font-family: 'Spoqa Han Sans', "Nanum Gothic","맑은 고딕","Malgun Gothic","돋움",'Helvetica Neue', Helvetica, Arial, sans-serif;
+    font-family: 'Noto Sans KR', "Nanum Gothic","맑은 고딕","Malgun Gothic","돋움",'Helvetica Neue', Helvetica, Arial, sans-serif;
     font-size: 1rem;
     line-height: 1.6;
     color: rgb(51, 51, 51);


### PR DESCRIPTION
…다국어글꼴)로 바꿈
